### PR TITLE
Update readme and deps

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           version: "1.10"
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; PackageSpec(path=pwd())]); Pkg.instantiate()'
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'draft') == false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@latest
         with:
-          version: "1.9"
+          version: "1.10"
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop([PackageSpec(url="https://github.com/bcube-project/Bcube.jl"), PackageSpec(path=pwd())]); Pkg.instantiate()'
+        run: julia --project=docs/ -e 'using Pkg; PackageSpec(path=pwd())]); Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.10'
+          - "1.10"
         os:
           - ubuntu-latest
         arch:
@@ -41,7 +41,7 @@ jobs:
             ${{ runner.os }}-test-
             ${{ runner.os }}-
       - name: Install dependencies
-        run: julia --color=yes --project=. -e 'using Pkg; Pkg.add(url="https://github.com/bcube-project/Bcube.jl", rev="main"); Pkg.instantiate(); Pkg.precompile();'
+        run: julia --color=yes --project=. -e 'using Pkg; Pkg.instantiate(); Pkg.precompile();'
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
       - name: Upload coverage reports to Codecov

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,11 @@
 name = "BcubeTutorials"
 uuid = "96b9ee7b-4a19-4ce3-a39f-9fbf54b5b072"
 authors = ["Ghislain Blanchard, Lokman Bennani and Maxime Bouyges"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 Bcube = "cf06320b-b7f3-4748-8003-81a6b6979792"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -15,7 +13,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]
-Bcube = "0.1.1"
+Bcube = "0.1.4"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/README.md
+++ b/README.md
@@ -11,21 +11,20 @@ All the **tutorials** can be ran locally with the following steps.
 First, clone the repository
 
 ```bash
-$ git clone https://bcube-project.github.io/BcubeTutorials.jl
+$ git clone https://github.com/bcube-project/BcubeTutorials.jl.git
 $ cd BcubeTutorials.jl/
 ```
 
 Then, set up the environnement and run the script.
 
 ```julia-repl
-julia> using Pkg
-julia> Pkg.activate(".")
-julia> Pkg.add(PackageSpec(url="https://github.com/bcube-project/Bcube.jl"))
-julia> Pkg.instantiate()
+pkg> activate .
+(BcubeTutorials) pkg> instantiate
 julia> include("src/tutorial/helmholtz.jl")
 ```
 
 Regarding the **examples**, some of them require additionnal dependencies. Hence each example is associated to a specific environment:
+
 ```julia-repl
 julia> cd("src/example/covo")
 julia> using Pkg
@@ -34,6 +33,23 @@ julia> Pkg.add(PackageSpec(url="https://github.com/bcube-project/Bcube.jl"))
 julia> Pkg.instantiate()
 julia> include("covo.jl")
 ```
+
+## Build the documentation
+
+To browse the online documentation, simply click on the blue badge at the top of this README. If you would like to build the documentation yourself, for an offline access for instance, you can do it with the following commands.
+
+```bash
+$ git clone https://github.com/bcube-project/BcubeTutorials.jl.git
+$ cd BcubeTutorials.jl
+```
+
+```julia-repl
+pkg> activate .
+(BcubeTutorials) pkg> instantiate
+julia> include("docs/make.jl")
+```
+
+You can then browse `BcubeTutorials.jl/docs/build/index.html`.
 
 ## Authors
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,21 +19,20 @@ All the **tutorials** can be ran locally with the following steps.
 First, clone the repository
 
 ```bash
-$ git clone https://bcube-project.github.io/BcubeTutorials.jl
+$ git clone https://github.com/bcube-project/BcubeTutorials.jl.git
 $ cd BcubeTutorials.jl/
 ```
 
 Then, set up the environnement and run the script.
 
 ```julia-repl
-julia> using Pkg
-julia> Pkg.activate(".")
-julia> Pkg.add(PackageSpec(url="https://github.com/bcube-project/Bcube.jl"))
-julia> Pkg.instantiate()
+pkg> activate .
+(BcubeTutorials) pkg> instantiate
 julia> include("src/tutorial/helmholtz.jl")
 ```
 
 Regarding the **examples**, some of them require additionnal dependencies. Hence each example is associated to a specific environment:
+
 ```julia-repl
 julia> cd("src/example/covo")
 julia> using Pkg
@@ -42,6 +41,23 @@ julia> Pkg.add(PackageSpec(url="https://github.com/bcube-project/Bcube.jl"))
 julia> Pkg.instantiate()
 julia> include("covo.jl")
 ```
+
+## Build the documentation
+
+To browse the online documentation, simply click on the blue badge at the top of this README. If you would like to build the documentation yourself, for an offline access for instance, you can do it with the following commands.
+
+```bash
+$ git clone https://github.com/bcube-project/BcubeTutorials.jl.git
+$ cd BcubeTutorials.jl/
+```
+
+```julia-repl
+pkg> activate .
+(BcubeTutorials) pkg> instantiate
+julia> include("docs/make.jl")
+```
+
+You can then browse `BcubeTutorials.jl/docs/build/index.html`.
 
 ## Authors
 


### PR DESCRIPTION
Tiny PR to prepare new tag. 

@ghislainb :
1. do you want `BcubeTutorials` tag to match exactly `Bcube` tag? For the present case it would mean moving from 0.1.1 to 0.1.4. I don't think this is a good idea but I am not 100% against it.
2. From what I understand [here](https://pkgdocs.julialang.org/dev/creating-packages/#adding-tests-to-packages) the preferred way to setup unit tests is now to place `Test` etc dependencies in a `test/Project.toml` folder, as in Bcube (even though in Bcube we actually do both). Do you want me to use this PR to change this?
3. In `ci.yaml`, we explicitely designates `Bcube` with the git repo (instead of the registry). I think we should leave like this right? Otherwise I am afraid that tests will always be run with the registry-Bcube instead of the current development Bcube?