### PR TITLE
Upgrade examples with `BcubeVTK`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,27 +1,27 @@
 name = "BcubeTutorials"
 uuid = "96b9ee7b-4a19-4ce3-a39f-9fbf54b5b072"
 authors = ["Ghislain Blanchard, Lokman Bennani and Maxime Bouyges"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 Bcube = "cf06320b-b7f3-4748-8003-81a6b6979792"
+BcubeVTK = "f7a61acb-f482-4505-b2eb-e9cadd76b6b4"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+FastTransforms = "057dd010-8810-581a-b7be-e3fc3b93f78c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
-FastTransforms = "057dd010-8810-581a-b7be-e3fc3b93f78c"
 ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]
-Bcube = "0.1.10"
+Bcube = "0.2"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/src/example/constrained_poisson/Project.toml
+++ b/src/example/constrained_poisson/Project.toml
@@ -1,8 +1,8 @@
 [deps]
 Bcube = "cf06320b-b7f3-4748-8003-81a6b6979792"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
+BcubeVTK = "f7a61acb-f482-4505-b2eb-e9cadd76b6b4"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-Bcube = "0.1.3"
+Bcube = "0.2.0"

--- a/src/example/constrained_poisson/constrained_poisson.jl
+++ b/src/example/constrained_poisson/constrained_poisson.jl
@@ -40,9 +40,9 @@ println("Running constrained poisson with MultiplierFESpace API example...") #hi
 
 # import necessary packages
 using Bcube
+using BcubeVTK
 using LinearAlgebra
 using SparseArrays
-using WriteVTK
 using Test #src
 
 const outputpath = joinpath(@__DIR__, "..", "..", "..", "myout", "constrained_poisson")
@@ -114,8 +114,8 @@ u_ref = PhysicalFunction(x -> cos(4.0 * π * (x[1]^2 + x[2]^2)))
 error = u_ref - u
 
 vars = Dict("Numerical solution" => u, "Analytical solution" => u_ref, "error" => error)
-filename = joinpath(outputpath, "output")
-Bcube.write_vtk_lagrange(filename, vars, mesh, U)
+filename = joinpath(outputpath, "output.pvd")
+write_file(filename, mesh, U, vars)
 
 l2(u) = sqrt(sum(Bcube.compute(∫(u ⋅ u)dΩ)))
 el2 = l2(error) / l2(u_ref)

--- a/src/example/constrained_poisson/constrained_poisson_manual_assembly.jl
+++ b/src/example/constrained_poisson/constrained_poisson_manual_assembly.jl
@@ -47,9 +47,9 @@ println("Running constrained poisson API example...") #hide
 
 # import necessary packages
 using Bcube
+using BcubeVTK
 using LinearAlgebra
 using SparseArrays
-using WriteVTK
 
 const outputpath = joinpath(@__DIR__, "../../../myout/constrained_poisson/")
 mkpath(outputpath)
@@ -115,8 +115,8 @@ u_ref = PhysicalFunction(x -> cos(4.0 * π * (x[1]^2 + x[2]^2)))
 error = u_ref - u
 
 vars = Dict("Numerical solution" => u, "Analytical solution" => u_ref, "error" => error)
-filename = joinpath(outputpath, "output")
-Bcube.write_vtk_lagrange(filename, vars, mesh, U)
+filename = joinpath(outputpath, "output.pvd")
+write_file(filename, mesh, U, vars)
 
 l2(u) = sqrt(sum(Bcube.compute(∫(u ⋅ u)dΩ)))
 el2 = l2(error) / l2(u_ref)

--- a/src/example/covo/Project.toml
+++ b/src/example/covo/Project.toml
@@ -2,9 +2,12 @@
 Bcube = "cf06320b-b7f3-4748-8003-81a6b6979792"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
+BcubeVTK = "f7a61acb-f482-4505-b2eb-e9cadd76b6b4"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+
+[compat]
+Bcube = "0.2"

--- a/src/example/covo/covo.jl
+++ b/src/example/covo/covo.jl
@@ -3,9 +3,9 @@ println("Running covo example...") #hide
 
 const dir = string(@__DIR__, "/")
 using Bcube
+using BcubeVTK
 using LinearAlgebra
 using StaticArrays
-using WriteVTK # only for 'VTKCellData'
 using Profile
 using StaticArrays
 using InteractiveUtils
@@ -240,27 +240,18 @@ function append_vtk(vtk, mesh, vars, t, params)
     vtk_degree = maximum(x -> get_degree(Bcube.get_function_space(get_fespace(x))), vars)
     vtk_degree = max(1, mesh_degree, vtk_degree)
 
-    _ρ = var_on_nodes_discontinuous(ρ, mesh, vtk_degree)
-    _ρu = var_on_nodes_discontinuous(ρu, mesh, vtk_degree)
-    _ρE = var_on_nodes_discontinuous(ρE, mesh, vtk_degree)
-    _ϕ = var_on_nodes_discontinuous(ϕ, mesh, vtk_degree)
-
-    _p = pressure.(_ρ, _ρu, _ρE, γ)
-    dict_vars_dg = Dict(
-        "rho" => (_ρ, VTKPointData()),
-        "rhou" => (_ρu, VTKPointData()),
-        "rhoE" => (_ρE, VTKPointData()),
-        "phi" => (_ϕ, VTKPointData()),
-        "p" => (_p, VTKPointData()),
-    )
-    Bcube.write_vtk_discontinuous(
-        vtk.basename * "_DG",
-        vtk.ite,
-        t,
+    # p = pressure(ρ, ρu, ρE, γ)
+    p = pressure ∘ (ρ, ρu, ρE, γ)
+    dict_vars_dg = Dict("rho" => ρ, "rhou" => ρu, "rhoE" => ρE, "phi" => ϕ, "p" => p)
+    write_file(
+        vtk.basename * "_DG.pvd",
         mesh,
         dict_vars_dg,
-        vtk_degree;
-        append = vtk.ite > 0,
+        vtk.ite,
+        t;
+        discontinuous = true,
+        mesh_degree = vtk_degree,
+        collection_append = vtk.ite > 0,
     )
 
     # Update counter

--- a/src/example/euler_naca_steady/Project.toml
+++ b/src/example/euler_naca_steady/Project.toml
@@ -2,13 +2,17 @@
 Bcube = "cf06320b-b7f3-4748-8003-81a6b6979792"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
+BcubeVTK = "f7a61acb-f482-4505-b2eb-e9cadd76b6b4"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 SparseDiffTools = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
+
+[compat]
+Bcube = "0.2"

--- a/src/example/euler_naca_steady/euler_naca_steady.jl
+++ b/src/example/euler_naca_steady/euler_naca_steady.jl
@@ -233,9 +233,9 @@ function append_vtk(vtk, mesh, vars, t, params; res = nothing)
         "rhoE" => ρE,
         "Cp" => Cp,
         "Mach" => Ma,
-        "rho_mean" => Bcube.cell_mean(ρ, params.dΩ),
-        "rhou_mean" => Bcube.cell_mean(ρu, params.dΩ),
-        "rhoE_mean" => Bcube.cell_mean(ρE, params.dΩ),
+        "rho_mean" => cell_mean(ρ, params.dΩ),
+        "rhou_mean" => cell_mean(ρu, params.dΩ),
+        "rhoE_mean" => cell_mean(ρE, params.dΩ),
         "lim_rho" => params.limρ,
         "lim_all" => params.limAll,
     )
@@ -487,7 +487,7 @@ function isoutofdomain(dof, p, t)
     any(isnan, dof) && return true
 
     q = FEFunction(p.Q, dof)
-    q_mean = map(get_values, Bcube.cell_mean(q, p.cache.cacheCellMean))
+    q_mean = map(get_values, cell_mean(q, p.cache.cacheCellMean))
     p_mean = pressure.(q_mean..., stateInit.γ)
 
     negative_ρ = any(x -> x < 0, q_mean[1])
@@ -596,7 +596,7 @@ function apply_limitation!(q::Bcube.AbstractFEFunction, ode_params)
     mesh = get_mesh(get_domain(params.dΩ))
     ρ, ρu, ρE = q
 
-    ρ_mean, ρu_mean, ρE_mean = Bcube.cell_mean(q, cache.cacheCellMean)
+    ρ_mean, ρu_mean, ρE_mean = cell_mean(q, cache.cacheCellMean)
 
     _limρ, ρ_proj = linear_scaling_limiter(
         ρ,

--- a/src/example/heat_equation_sphere/heat_equation_sphere.jl
+++ b/src/example/heat_equation_sphere/heat_equation_sphere.jl
@@ -125,7 +125,7 @@ function run(;
 )
 
     ## Settings
-    out_dir = joinpath(@__DIR__, "../../../myout/heat_eqn_sphere")
+    out_dir = joinpath(@__DIR__, "..", "..", "..", "myout", "heat_eqn_sphere")
     mkpath(out_dir)
 
     ## Mesh

--- a/src/example/heat_equation_sphere/heat_equation_sphere.jl
+++ b/src/example/heat_equation_sphere/heat_equation_sphere.jl
@@ -18,7 +18,7 @@ module HeatEquationSphere #hide
 # ![](../assets/heat_equation_sphere.gif)
 #
 using Bcube
-using WriteVTK
+using BcubeVTK
 using LinearAlgebra
 using StaticArrays
 using FastTransforms
@@ -69,65 +69,45 @@ mutable struct VtkHandler
     mesh::Any
     θ::Any
     θ_centers::Any
-    θ_vertices::Any
     ϕ::Any
     ϕ_centers::Any
-    ϕ_vertices::Any
     ν::Any
     ν_centers::Any
-    ν_vertices::Any
     function VtkHandler(basename, mesh)
         θ = PhysicalFunction(x -> cart2sphere(x)[2])
-        θ_centers = var_on_centers(θ, mesh)
-        θ_vertices = var_on_vertices(θ, mesh)
+        θ_centers = MeshCellData(var_on_centers(θ, mesh))
 
         ϕ = PhysicalFunction(x -> cart2sphere(x)[3])
-        ϕ_centers = var_on_centers(ϕ, mesh)
-        ϕ_vertices = var_on_vertices(ϕ, mesh)
+        ϕ_centers = MeshCellData(var_on_centers(ϕ, mesh))
 
         ν = Bcube.CellNormal(mesh)
-        ν_centers = transpose(var_on_centers(ν, mesh))
-        ν_vertices = transpose(var_on_vertices(ν, mesh))
+        ν_centers = var_on_centers(ν, mesh)
+        _ν_centers = MeshCellData([SA[ν_centers[i, :]...] for i in 1:ncells(mesh)])
 
-        new(
-            basename,
-            0,
-            mesh,
-            θ,
-            θ_centers,
-            θ_vertices,
-            ϕ,
-            ϕ_centers,
-            ϕ_vertices,
-            ν,
-            ν_centers,
-            ν_vertices,
-        )
+        new(basename, 0, mesh, θ, θ_centers, ϕ, ϕ_centers, ν, _ν_centers)
     end
 end
 
 function append_vtk(vtk, u::Bcube.AbstractFEFunction, t)
-    values_vertices = var_on_vertices(u, vtk.mesh)
-    values_centers = var_on_centers(u, vtk.mesh)
+    values_centers = MeshCellData(var_on_centers(u, vtk.mesh))
 
     ## Write
-    Bcube.write_vtk(
+    write_file(
         vtk.basename,
-        vtk.ite,
-        t,
         vtk.mesh,
         Dict(
-            "u_centers" => (values_centers, VTKCellData()),
-            "u_vertices" => (values_vertices, VTKPointData()),
-            "θ_centers" => (vtk.θ_centers, VTKCellData()),
-            "θ_vertices" => (vtk.θ_vertices, VTKPointData()),
-            "ϕ_centers" => (vtk.ϕ_centers, VTKCellData()),
-            "ϕ_vertices" => (vtk.ϕ_vertices, VTKPointData()),
-            "ν_centers" => (vtk.ν_centers, VTKCellData()),
-            "ν_vertices" => (vtk.ν_vertices, VTKPointData()),
+            "u_centers" => values_centers,
+            "u_vertices" => u,
+            "θ_centers" => vtk.θ_centers,
+            "θ_vertices" => vtk.θ,
+            "ϕ_centers" => vtk.ϕ_centers,
+            "ϕ_vertices" => vtk.ϕ,
+            "ν_centers" => vtk.ν_centers,
+            "ν_vertices" => vtk.ν,
         ),
-        ;
-        append = vtk.ite > 0,
+        vtk.ite,
+        t;
+        collection_append = vtk.ite > 0,
     )
 
     ## Update counter
@@ -160,7 +140,7 @@ function run(;
     dΩ = Measure(CellDomain(mesh), 2 * degree + 1)
 
     ## Prepare output
-    vtk = VtkHandler(joinpath(out_dir, "result_d$(degree)"), mesh)
+    vtk = VtkHandler(joinpath(out_dir, "result_d$(degree).pvd"), mesh)
 
     ## Discretization
     U = TrialFESpace(FunctionSpace(:Lagrange, degree), mesh)

--- a/src/example/heat_equation_two_layers/heat_equation_two_layers.jl
+++ b/src/example/heat_equation_two_layers/heat_equation_two_layers.jl
@@ -16,8 +16,8 @@ println("Running heat equation two layers example...") #hide
 
 const dir = joinpath(@__DIR__, "..", "..", "..") # BcubeTutorials dir
 using Bcube
+using BcubeVTK
 using LinearAlgebra
-using WriteVTK
 using Test #src
 
 function T_analytical_two_layers(x, λ1, λ2, T0, T1, L)
@@ -83,11 +83,9 @@ function run_steady_two_layers_method1(; degree)
     Tcn = var_on_centers(ϕ, mesh)
     Tca = var_on_centers(T_analytical, mesh)
     dict_vars =
-        Dict("Temperature" => (Tcn, VTKCellData()), "Temperature_a" => (Tca, VTKCellData()))
-    write_vtk(
-        joinpath(outputpath, "result_steady_heat_equation_two_layers_method1"),
-        0,
-        0.0,
+        Dict("Temperature" => MeshCellData(Tcn), "Temperature_a" => MeshCellData(Tca))
+    write_file(
+        joinpath(outputpath, "result_steady_heat_equation_two_layers_method1.pvd"),
         mesh,
         dict_vars,
     )
@@ -145,11 +143,9 @@ function run_steady_two_layers_method2(; degree)
     Tcn = var_on_centers(ϕ, mesh)
     Tca = var_on_centers(T_analytical, mesh)
     dict_vars =
-        Dict("Temperature" => (Tcn, VTKCellData()), "Temperature_a" => (Tca, VTKCellData()))
-    write_vtk(
-        joinpath(outputpath, "result_steady_heat_equation_two_layers_method2"),
-        0,
-        0.0,
+        Dict("Temperature" => MeshCellData(Tcn), "Temperature_a" => MeshCellData(Tca))
+    write_file(
+        joinpath(outputpath, "result_steady_heat_equation_two_layers_method2.pvd"),
         mesh,
         dict_vars,
     )

--- a/src/example/linear_elasticity/Project.toml
+++ b/src/example/linear_elasticity/Project.toml
@@ -1,5 +1,8 @@
 [deps]
 Bcube = "cf06320b-b7f3-4748-8003-81a6b6979792"
+BcubeVTK = "f7a61acb-f482-4505-b2eb-e9cadd76b6b4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[compat]
+Bcube = "0.2"

--- a/src/example/linear_elasticity/linear_elasticity.jl
+++ b/src/example/linear_elasticity/linear_elasticity.jl
@@ -5,8 +5,8 @@ println("Running linear elasticity API example...") #hide
 
 const dir = string(@__DIR__, "/") # bcube/example dir
 using Bcube
+using BcubeVTK
 using LinearAlgebra
-using WriteVTK
 using StaticArrays
 
 # function space (here we shall use Lagrange P1 elements) and quadrature degree.
@@ -15,7 +15,7 @@ const degree = 1 # FunctionSpace degree
 const degquad = 2 * degree + 1
 
 # Input and output paths
-const outputpath = dir * "../../../myout/elasticity/"
+const outputpath = dir * "../../../myout/linear_elasticity/"
 const meshpath = dir * "../../../input/mesh/domainElast_tri.msh"
 
 # Time stepping scheme params
@@ -67,11 +67,10 @@ function run_steady()
     sys = Bcube.AffineFESystem(a, l, U_vec, V_vec)
     ϕ = Bcube.solve(sys)
 
-    Un = var_on_vertices(ϕ, mesh)
     # Write the obtained FE solution
-    dict_vars = Dict("Displacement" => (transpose(Un), VTKPointData()))
+    dict_vars = Dict("Displacement" => ϕ)
     mkpath(outputpath)
-    write_vtk(outputpath * "result_elasticity", itime, t, mesh, dict_vars; append = false)
+    write_file(outputpath * "result_elasticity.pvd", mesh, dict_vars)
 end
 
 # Function that performs a time step using a Newmark α-HHT scheme
@@ -132,11 +131,10 @@ function run_unsteady()
     G0 = zeros(Bcube.get_ndofs(U_vec))
 
     # Write initial solution
-    Un = var_on_vertices(ϕ, mesh)
     # Write the obtained FE solution
-    dict_vars = Dict("Displacement" => (transpose(Un), VTKPointData()))
+    dict_vars = Dict("Displacement" => ϕ)
     mkpath(outputpath)
-    write_vtk(outputpath * "result_elasticity", 0, 0.0, mesh, dict_vars; append = false)
+    write_file(outputpath * "result_elasticity.pvd", mesh, dict_vars, 0, 0.0)
 
     # Time loop
     totalTime = 1.0e-3
@@ -164,16 +162,15 @@ function run_unsteady()
 
         # Write solution
         if itime % 10 == 0
-            Un = var_on_vertices(ϕ, mesh)
             # Write the obtained FE solution
-            dict_vars = Dict("Displacement" => (transpose(Un), VTKPointData()))
-            write_vtk(
-                outputpath * "result_elasticity",
-                itime,
-                t,
+            dict_vars = Dict("Displacement" => ϕ)
+            write_file(
+                outputpath * "result_elasticity.pvd",
                 mesh,
-                dict_vars;
-                append = true,
+                dict_vars,
+                itime,
+                t;
+                collection_append = true,
             )
             # In order to use the warp function in paraview (solid is deformed using the displacement field)
             # the calculator filter has to be used with the following formula to reconstruct a 3D displacement field

--- a/src/example/linear_thermoelasticity/Project.toml
+++ b/src/example/linear_thermoelasticity/Project.toml
@@ -1,5 +1,8 @@
 [deps]
 Bcube = "cf06320b-b7f3-4748-8003-81a6b6979792"
+BcubeVTK = "f7a61acb-f482-4505-b2eb-e9cadd76b6b4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[compat]
+Bcube = "0.2"

--- a/src/example/linear_thermoelasticity/linear_thermoelasticity.jl
+++ b/src/example/linear_thermoelasticity/linear_thermoelasticity.jl
@@ -5,8 +5,8 @@ println("Running linear thermo-elasticity API example...") #hide
 
 const dir = string(@__DIR__, "/") # Bcube dir
 using Bcube
+using BcubeVTK
 using LinearAlgebra
-using WriteVTK
 using StaticArrays
 
 # Function space (here we shall use Lagrange P1 elements) and quadrature degree.
@@ -15,7 +15,7 @@ const degree = 1 # FunctionSpace degree
 const degquad = 2 * degree + 1
 
 # Input and output paths
-const outputpath = joinpath(dir, "../../../myout/elasticity/")
+const outputpath = joinpath(dir, "../../../myout/linear_thermoelasticity/")
 const meshpath = joinpath(dir, "../../../input/mesh/domainThermoElast_tri.msh")
 
 # Time stepping scheme params
@@ -143,20 +143,16 @@ function run_unsteady()
     Bcube.apply_dirichlet_to_matrix!((AT, MT), U_scal, V_scal, mesh)
 
     ## Write initial solution
-    Un = var_on_vertices(U, mesh)
-    Un = transpose(Un)
-    Tn = var_on_vertices(T, mesh)
     mkpath(outputpath)
-    dict_vars =
-        Dict("Displacement" => (Un, VTKPointData()), "Temperature" => (Tn, VTKPointData()))
+    dict_vars = Dict("Displacement" => U, "Temperature" => T)
     ## Write the obtained FE solution
-    write_vtk(
-        outputpath * "result_thermoelasticity",
-        0,
-        0.0,
+    write_file(
+        outputpath * "result_thermoelasticity.pvd",
         mesh,
-        dict_vars;
-        append = false,
+        dict_vars,
+        0,
+        0.0;
+        collection_append = false,
     )
 
     ## Time loop
@@ -190,22 +186,15 @@ function run_unsteady()
 
         ## Write solution
         if itime % 10 == 0
-            Un = var_on_vertices(U, mesh)
-            Un = transpose(Un)
-            Tn = var_on_vertices(T, mesh)
-            mkpath(outputpath)
-            dict_vars = Dict(
-                "Displacement" => (Un, VTKPointData()),
-                "Temperature" => (Tn, VTKPointData()),
-            )
+            dict_vars = Dict("Displacement" => U, "Temperature" => T)
             ## Write the obtained FE solution
-            write_vtk(
-                outputpath * "result_thermoelasticity",
-                itime,
-                t,
+            write_file(
+                outputpath * "result_thermoelasticity.pvd",
                 mesh,
-                dict_vars;
-                append = true,
+                dict_vars,
+                itime,
+                t;
+                collection_append = true,
             )
             ## In order to use the warp function in paraview (solid is deformed using the displacement field)
             ## the calculator filter has to be used with the following formula to reconstruct a 3D displacement field

--- a/src/example/poisson_dg/Project.toml
+++ b/src/example/poisson_dg/Project.toml
@@ -1,6 +1,9 @@
 [deps]
 Bcube = "cf06320b-b7f3-4748-8003-81a6b6979792"
+BcubeVTK = "f7a61acb-f482-4505-b2eb-e9cadd76b6b4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
+
+[compat]
+Bcube = "0.2"

--- a/src/example/poisson_dg/poisson_dg.jl
+++ b/src/example/poisson_dg/poisson_dg.jl
@@ -6,12 +6,12 @@ println("Running poisson DG example...") #hide
 
 # import necessary packages
 using Bcube
+using BcubeVTK
 using LinearAlgebra
 using SparseArrays
-using WriteVTK
 using StaticArrays
 
-const outputpath = joinpath(@__DIR__, "../myout/poisson_dg/")
+const outputpath = joinpath(@__DIR__, "..", "..", "..", "myout", "poisson_dg")
 isdir(outputpath) || mkpath(outputpath)
 const degree = 3
 const degree_quad = 2 * degree + 1
@@ -73,7 +73,7 @@ function main()
     e = uₐ - uh
 
     vars = Dict("uh" => uh, "u_ref" => uₐ, "error" => e)
-    Bcube.write_vtk_lagrange(joinpath(outputpath, "output"), vars, mesh, U)
+    write_file(joinpath(outputpath, "output.pvd"), mesh, U, vars)
 
     el2 = l2(e)
     eh1 = h1(e)

--- a/src/example/runexamples.jl
+++ b/src/example/runexamples.jl
@@ -1,7 +1,0 @@
-# Alias to script directory : helps running this file from anywhere
-const dir = string(@__DIR__, "/../") # Bcube dir
-
-# Run examples
-include(dir * "example/covo.jl")
-include(dir * "example/euler_naca_steady.jl")
-include(dir * "example/linear_elasticity.jl")

--- a/src/example/shallow_water/Project.toml
+++ b/src/example/shallow_water/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Bcube = "cf06320b-b7f3-4748-8003-81a6b6979792"
+BcubeVTK = "f7a61acb-f482-4505-b2eb-e9cadd76b6b4"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -8,4 +9,6 @@ Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SparseDiffTools = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
+
+[compat]
+Bcube = "0.2"

--- a/src/example/shallow_water/shallow_water.jl
+++ b/src/example/shallow_water/shallow_water.jl
@@ -120,8 +120,8 @@ println("Running shallow_water example...") #hide
 
 const dir = string(@__DIR__, "/")
 using Bcube
+using BcubeVTK
 using LinearAlgebra
-using WriteVTK
 using StaticArrays
 using BenchmarkTools
 using Roots
@@ -298,29 +298,27 @@ function append_vtk(vtk, mesh, vars, t, params)
     vtk_degree = maximum(x -> get_degree(Bcube.get_function_space(get_fespace(x))), vars)
     vtk_degree = max(1, mesh_degree, vtk_degree)
 
-    _h  = var_on_nodes_discontinuous(h, mesh, vtk_degree)
-    _hu = var_on_nodes_discontinuous(hu, mesh, vtk_degree)
-    _u  = velocity.(_h, _hu)
+    u = velocity ∘ (h, hu)
 
     # Write
     dict_vars_dg = Dict(
-        "h" => (_h, VTKPointData()),
-        "hu" => (_hu, VTKPointData()),
-        "u" => (_u, VTKPointData()),
-        "h_mean" => (get_values(Bcube.cell_mean(h, params.dΩ)), VTKCellData()),
-        "hu_mean" => (get_values(Bcube.cell_mean(hu, params.dΩ)), VTKCellData()),
-        "lim_h" => (get_values(params.limh), VTKCellData()),
-        "centers" => (params.xc, VTKCellData()),
+        "h" => h,
+        "hu" => hu,
+        "u" => u,
+        "h_mean" => cell_mean(h, params.dΩ),
+        "hu_mean" => cell_mean(hu, params.dΩ),
+        "lim_h" => params.limh,
+        "centers" => MeshCellData(params.xc),
     )
 
-    Bcube.write_vtk_discontinuous(
-        vtk.basename * "_DG",
-        vtk.ite,
-        t,
+    write_file(
+        vtk.basename * "_DG.pvd",
         mesh,
         dict_vars_dg,
-        vtk_degree;
-        append = vtk.ite > 0,
+        vtk.ite,
+        t;
+        mesh_degree = vtk_degree,
+        collection_append = vtk.ite > 0,
     )
 
     # Update counter
@@ -404,8 +402,8 @@ function run_simulation(stateInit)
     )
 
     # create CellData to store limiter values
-    limh = Bcube.MeshCellData(ones(ncells(mesh)))
-    limAll = Bcube.MeshCellData(ones(ncells(mesh)))
+    limh = MeshCellData(ones(ncells(mesh)))
+    limAll = MeshCellData(ones(ncells(mesh)))
     params = (params..., limh = limh, limAll = limAll)
 
     # Init vtk handler
@@ -481,7 +479,7 @@ function run_simulation(stateInit)
 end
 
 function compute_timestep!(q, dΩ, dimcar, CFL)
-    q_mean = map(Base.Fix2(Bcube.cell_mean, dΩ), get_fe_functions(q))
+    q_mean = map(Base.Fix2(cell_mean, dΩ), get_fe_functions(q))
     λ(x...) = shallow_water_maxeigval(x, stateInit.gravity)
     λmax = map(λ, get_values.(q_mean)...)
     Δt = CFL * minimum(dimcar ./ λmax)
@@ -530,7 +528,7 @@ function apply_limitation!(q, params, cache)
     h, hu = q
     dΩ = params.dΩ
 
-    q_mean = Bcube.cell_mean(q, cache.cacheCellMean)
+    q_mean = cell_mean(q, cache.cacheCellMean)
 
     _limh, _h_proj = linear_scaling_limiter(
         h,

--- a/src/example/transport_hypersurface/transport_hypersurface.jl
+++ b/src/example/transport_hypersurface/transport_hypersurface.jl
@@ -287,7 +287,7 @@ function scalar_circle(;
     lim_u, _u = linear_scaling_limiter(u, dΩ; DMPrelax, mass = M)
     isLimiterActive && (u.dofValues .= _u.dofValues)
 
-    u_mean = Bcube.cell_mean(u, dΩ)
+    u_mean = cell_mean(u, dΩ)
     t = 0.0
     plt = plot_solution(0, t, u, mesh, xcenters, ycenters, xnodes, ynodes)
     append_vtk(vtk, u, lim_u, u_mean, t)
@@ -324,7 +324,7 @@ function scalar_circle(;
 
         ## Output results
         if ite % (nite ÷ _nout) == 0
-            u_mean = Bcube.cell_mean(u, dΩ)
+            u_mean = cell_mean(u, dΩ)
             append_vtk(vtk, u, lim_u, u_mean, t)
             plt = plot_solution(vtk.ite, t, u, mesh, xcenters, ycenters, xnodes, ynodes)
             frame(anim, plt)
@@ -478,7 +478,7 @@ function scalar_cylinder(;
     function append_vtk(vtk, u::Bcube.AbstractFEFunction, lim_u, t)
         vars = Dict(
             "u" => u,
-            "u_mean" => Bcube.cell_mean(u, vtk.dΩ),
+            "u_mean" => cell_mean(u, vtk.dΩ),
             "lim_u" => lim_u,
             "c" => vtk.c,
             "cellnormal" => Bcube.CellNormal(vtk.mesh),
@@ -853,7 +853,7 @@ function vector_cylinder(;
         lim_u = MeshCellData(zero(get_dof_values(u))) ## dummy, just for the output
     end
 
-    u_mean = Bcube.cell_mean(u, dΩ)
+    u_mean = cell_mean(u, dΩ)
     t = 0.0
     append_vtk(vtk, u, lim_u, u_mean, t)
 
@@ -885,7 +885,7 @@ function vector_cylinder(;
 
         ## Output results
         if ite % (nitemax ÷ _nout) == 0
-            u_mean = Bcube.cell_mean(u, dΩ)
+            u_mean = cell_mean(u, dΩ)
             append_vtk(vtk, u, lim_u, u_mean, t)
         end
     end
@@ -912,7 +912,7 @@ function scalar_torus(;
     function append_vtk(vtk, u::Bcube.AbstractFEFunction, lim_u, t)
         vars = Dict(
             "u" => u,
-            "u_mean" => Bcube.cell_mean(u, vtk.dΩ),
+            "u_mean" => cell_mean(u, vtk.dΩ),
             "lim_u" => lim_u,
             "c" => vtk.c,
             "cellnormal" => Bcube.CellNormal(vtk.mesh),

--- a/src/tutorial/heat_equation.jl
+++ b/src/tutorial/heat_equation.jl
@@ -67,11 +67,12 @@ Tcn = var_on_centers(ϕ, mesh)
 T_analytical = x -> 260.0 + (q / λ) * x[1] * (1.0 - 0.5 * x[1])
 Tca = map(T_analytical, get_cell_centers(mesh))
 
-# Write both the obtained FE solution and the analytical solution to a vtk file.
+# Write both the obtained FE solution and the analytical solution to a vtk file. To
+# write the data on mesh centers, we need to wrap them in a `MeshCellData` object.
+using BcubeVTK
 mkpath(outputpath)
-dict_vars =
-    Dict("Temperature" => (Tcn, VTKCellData()), "Temperature_a" => (Tca, VTKCellData()))
-write_vtk(outputpath * "result_steady_heat_equation", 0, 0.0, mesh, dict_vars)
+dict_vars = Dict("Temperature" => MeshCellData(Tcn), "Temperature_a" => MeshCellData(Tca))
+write_file(outputpath * "result_steady_heat_equation.pbd", mesh, dict_vars)
 
 # Compute and display the error
 @show norm(Tcn .- Tca, Inf) / norm(Tca, Inf)

--- a/src/tutorial/heat_equation.jl
+++ b/src/tutorial/heat_equation.jl
@@ -19,8 +19,8 @@ println("Running heat equation tutorial...") #hide
 # # Steady case
 # As usual, start by importing the necessary packages.
 using Bcube
+using BcubeVTK
 using LinearAlgebra
-using WriteVTK
 using Test #src
 
 # First we define some physical and numerical constants
@@ -72,7 +72,7 @@ Tca = map(T_analytical, get_cell_centers(mesh))
 using BcubeVTK
 mkpath(outputpath)
 dict_vars = Dict("Temperature" => MeshCellData(Tcn), "Temperature_a" => MeshCellData(Tca))
-write_file(outputpath * "result_steady_heat_equation.pbd", mesh, dict_vars)
+write_file(outputpath * "result_steady_heat_equation.pvd", mesh, dict_vars)
 
 # Compute and display the error
 @show norm(Tcn .- Tca, Inf) / norm(Tca, Inf)
@@ -128,8 +128,8 @@ Miter = factorize(M + Δt * A)
 
 # Write initial solution to a file
 mkpath(outputpath)
-dict_vars = Dict("Temperature" => (var_on_centers(ϕ, mesh), VTKCellData()))
-write_vtk(outputpath * "result_unsteady_heat_equation", 0, 0.0, mesh, dict_vars)
+dict_vars = Dict("Temperature" => MeshCellData(var_on_centers(ϕ, mesh)))
+write_file(outputpath * "result_unsteady_heat_equation.pvd", mesh, dict_vars, 0, 0.0)
 
 # Time loop
 itime = 0
@@ -148,14 +148,14 @@ while t <= totalTime
 
     ## Write solution (every 10 iterations)
     if itime % 10 == 0
-        dict_vars = Dict("Temperature" => (var_on_centers(ϕ, mesh), VTKCellData()))
-        write_vtk(
-            outputpath * "result_unsteady_heat_equation",
-            itime,
-            t,
+        dict_vars = Dict("Temperature" => MeshCellData(var_on_centers(ϕ, mesh)))
+        write_file(
+            outputpath * "result_unsteady_heat_equation.pvd",
             mesh,
-            dict_vars;
-            append = true,
+            dict_vars,
+            itime,
+            t;
+            collection_append = true,
         )
     end
 end

--- a/src/tutorial/linear_transport.jl
+++ b/src/tutorial/linear_transport.jl
@@ -36,8 +36,8 @@ println("Running linear transport example...") #hide
 # Start by importing the necessary packages:
 # Load the necessary packages
 using Bcube
+using BcubeVTK
 using LinearAlgebra
-using WriteVTK
 
 # Before all, to ease to ease the solution VTK output we will write a
 # structure to store the vtk filename and the number of iteration; and a function
@@ -52,18 +52,15 @@ mutable struct VtkHandler
 end
 
 function append_vtk(vtk, u::Bcube.AbstractFEFunction, t)
-    ## Values on center
-    values = var_on_nodes_discontinuous(u, vtk.mesh)
-
     ## Write
-    Bcube.write_vtk_discontinuous(
+    Bcube.write_file(
         vtk.basename,
-        vtk.ite,
-        t,
         vtk.mesh,
-        Dict("u" => (values, VTKPointData())),
-        1;
-        append = vtk.ite > 0,
+        Dict("u" => u),
+        vtk.ite,
+        t;
+        discontinuous = true,
+        collection_append = vtk.ite > 0,
     )
 
     ## Update counter
@@ -90,7 +87,7 @@ rm(tmp_path)
 # We can now init our `VtkHandler`
 out_dir = joinpath(@__DIR__, "..", "..", "myout", "linear_transport")
 mkpath(out_dir) #hide
-vtk = VtkHandler(joinpath(out_dir, "linear_transport"), mesh)
+vtk = VtkHandler(joinpath(out_dir, "linear_transport.pvd"), mesh)
 
 # As seen in the previous tutorial, the definition of trial and test spaces needs a mesh and
 # a function space. Here, we select Taylor space, and build discontinuous FE spaces with it.

--- a/src/tutorial/phase_field_supercooled.jl
+++ b/src/tutorial/phase_field_supercooled.jl
@@ -25,8 +25,8 @@ println("Running phase field supercooled equation example...") #hide
 # # Code
 # Load the necessary packages
 using Bcube
+using BcubeVTK
 using LinearAlgebra
-using WriteVTK
 using Random
 
 Random.seed!(1234) # to obtain reproductible results
@@ -97,11 +97,8 @@ apply_dirichlet_to_matrix!((C_ϕ, C_T), U, V, mesh)
 set_dof_values!(ϕ, d)
 set_dof_values!(T, d)
 
-dict_vars = Dict(
-    "Temperature" => (var_on_vertices(T, mesh), VTKPointData()),
-    "Phi" => (var_on_vertices(ϕ, mesh), VTKPointData()),
-)
-write_vtk(joinpath(out_dir, "result_phaseField_imex_1space"), 0, 0.0, mesh, dict_vars)
+dict_vars = Dict("Temperature" => T, "Phi" => ϕ)
+write_file(joinpath(out_dir, "result_phaseField_imex_1space.pvd"), mesh, dict_vars, 0, 0.0)
 
 # Factorize and allocate some vectors to increase performance
 C_ϕ = factorize(C_ϕ)
@@ -136,17 +133,14 @@ while t <= totalTime
 
     ## write solution in vtk format
     if itime % nout == 0
-        dict_vars = Dict(
-            "Temperature" => (var_on_vertices(T, mesh), VTKPointData()),
-            "Phi" => (var_on_vertices(ϕ, mesh), VTKPointData()),
-        )
-        write_vtk(
-            joinpath(out_dir, "result_phaseField_imex_1space"),
-            itime,
-            t,
+        dict_vars = Dict("Temperature" => T, "Phi" => ϕ)
+        write_file(
+            joinpath(out_dir, "result_phaseField_imex_1space.pvd"),
             mesh,
-            dict_vars;
-            append = true,
+            dict_vars,
+            itime,
+            t;
+            collection_append = true,
         )
     end
 end


### PR DESCRIPTION
All tutorials and examples have been upgraded to use `BcubeVTK`. All results have been checked manually!

Between the three PRs, this one should be merged last because it needs Bcube 0.2 and BcubeVTK