### PR TITLE
Handle dirichlet vector as SparseVector

### DIFF
--- a/src/example/incompressible_navier_stokes/incompressible_navier_stokes.jl
+++ b/src/example/incompressible_navier_stokes/incompressible_navier_stokes.jl
@@ -149,6 +149,7 @@ function run_unsteady_projection_method()
         ## assemble l1
         L1 = assemble_linear(l1, V_vel)
         Wd = Bcube.assemble_dirichlet_vector(U_vel, V_vel, mesh, time)
+        Wd = collect(Wd)
         ## Apply lift
         L1 = L1 - M0 * Wd
 
@@ -261,6 +262,7 @@ function run_unsteady_mixed()
         L = assemble_linear(l, V)
 
         Wd = Bcube.assemble_dirichlet_vector(U, V, mesh, time)
+        Wd = collect(Wd)
 
         ## Apply lift
         L = L - A0 * Wd

--- a/src/example/linear_thermoelasticity/linear_thermoelasticity.jl
+++ b/src/example/linear_thermoelasticity/linear_thermoelasticity.jl
@@ -135,6 +135,7 @@ function run_unsteady()
     ## except on dofs lying on a Dirichlet boundary, where they
     ## take the Dirichlet value
     Td = Bcube.assemble_dirichlet_vector(U_scal, V_scal, mesh)
+    Td = collect(Td)
 
     ## Apply lift
     LT = LT - AT * Td

--- a/src/example/stokes_flow/stokes_flow.jl
+++ b/src/example/stokes_flow/stokes_flow.jl
@@ -131,6 +131,7 @@ function run_steady()
 
     # build Dirichlet vector to apply lift
     Wd = Bcube.assemble_dirichlet_vector(U, V, mesh)
+    Wd = collect(Wd) # SparseVector -> Vector
 
     # Apply lift
     L = L - A * Wd
@@ -304,6 +305,7 @@ function run_unsteady()
         println("Time stepping : time = ", time, " / ", finalTime)
 
         Wd = Bcube.assemble_dirichlet_vector(U, V, mesh, time)
+        Wd = collect(Wd) # SparseVector -> Vector
 
         ## Apply lift
         L = -A0 * Wd

--- a/src/tutorial/heat_equation.jl
+++ b/src/tutorial/heat_equation.jl
@@ -109,8 +109,10 @@ L = assemble_linear(l, V)
 
 # Compute a vector of dofs whose values are zeros everywhere
 # except on dofs lying on a Dirichlet boundary, where they
-# take the Dirichlet value
-Ud = assemble_dirichlet_vector(U, V, mesh)
+# take the Dirichlet value. The returned vector is a "SparseVector".
+# Since we will use it in a linear system inversion, we must convert it
+# to a "regular" vector.
+Ud = collect(assemble_dirichlet_vector(U, V, mesh))
 
 # Apply lift
 L = L - A * Ud

--- a/src/tutorial/phase_field_supercooled.jl
+++ b/src/tutorial/phase_field_supercooled.jl
@@ -101,6 +101,7 @@ function main()
     # For this example, we don't use a lifting method to impose the Dirichlet, but `d`
     # is used to initialize the solution.
     d = assemble_dirichlet_vector(U, V, mesh)
+    d = collect(d) # SparseVector -> Vector
     apply_dirichlet_to_matrix!((C_ϕ, C_T), U, V, mesh)
 
     # Init solution and write it to a VTK file


### PR DESCRIPTION
Because linear system inversion in Julia does not handle SparseVector, we need to "convert" the SparseVectors obtained by `assemble_dirichlet_vector` to a `Vector`.