### PR TITLE
Update to Bcube 0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Bcube = "0.2"
+Bcube = "0.2, 0.3"
 
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/src/example/constrained_poisson/Project.toml
+++ b/src/example/constrained_poisson/Project.toml
@@ -6,4 +6,4 @@ BcubeVTK = "f7a61acb-f482-4505-b2eb-e9cadd76b6b4"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-Bcube = "0.2.0"
+Bcube = "0.2, 0.3"

--- a/src/example/covo/Project.toml
+++ b/src/example/covo/Project.toml
@@ -11,4 +11,4 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-Bcube = "0.2"
+Bcube = "0.2, 0.3"

--- a/src/example/euler_naca_steady/Project.toml
+++ b/src/example/euler_naca_steady/Project.toml
@@ -16,4 +16,4 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]
-Bcube = "0.2"
+Bcube = "0.2, 0.3"

--- a/src/example/heat_equation_sphere/Project.toml
+++ b/src/example/heat_equation_sphere/Project.toml
@@ -10,4 +10,4 @@ BcubeGmsh = "8c8b3700-392b-4630-b974-b8b78831232a"
 BcubeVTK = "f7a61acb-f482-4505-b2eb-e9cadd76b6b4"
 
 [compat]
-Bcube = "0.2"
+Bcube = "0.2, 0.3"

--- a/src/example/heat_equation_two_layers/Project.toml
+++ b/src/example/heat_equation_two_layers/Project.toml
@@ -4,4 +4,4 @@ BcubeGmsh = "8c8b3700-392b-4630-b974-b8b78831232a"
 BcubeVTK = "f7a61acb-f482-4505-b2eb-e9cadd76b6b4"
 
 [compat]
-Bcube = "0.2"
+Bcube = "0.2, 0.3"

--- a/src/example/incompressible_navier_stokes/Project.toml
+++ b/src/example/incompressible_navier_stokes/Project.toml
@@ -6,4 +6,4 @@ BcubeGmsh = "8c8b3700-392b-4630-b974-b8b78831232a"
 BcubeVTK = "f7a61acb-f482-4505-b2eb-e9cadd76b6b4"
 
 [compat]
-Bcube = "0.2"
+Bcube = "0.2, 0.3"

--- a/src/example/linear_elasticity/Project.toml
+++ b/src/example/linear_elasticity/Project.toml
@@ -6,4 +6,4 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-Bcube = "0.2"
+Bcube = "0.2, 0.3"

--- a/src/example/linear_thermoelasticity/Project.toml
+++ b/src/example/linear_thermoelasticity/Project.toml
@@ -6,4 +6,4 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-Bcube = "0.2"
+Bcube = "0.2, 0.3"

--- a/src/example/poisson_dg/Project.toml
+++ b/src/example/poisson_dg/Project.toml
@@ -7,4 +7,4 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-Bcube = "0.2"
+Bcube = "0.2, 0.3"

--- a/src/example/shallow_water/Project.toml
+++ b/src/example/shallow_water/Project.toml
@@ -12,4 +12,4 @@ SparseDiffTools = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-Bcube = "0.2"
+Bcube = "0.2, 0.3"

--- a/src/example/stokes_flow/Project.toml
+++ b/src/example/stokes_flow/Project.toml
@@ -7,4 +7,4 @@ BcubeGmsh = "8c8b3700-392b-4630-b974-b8b78831232a"
 BcubeVTK = "f7a61acb-f482-4505-b2eb-e9cadd76b6b4"
 
 [compat]
-Bcube = "0.2"
+Bcube = "0.2, 0.3"

--- a/src/example/transport_hypersurface/Project.toml
+++ b/src/example/transport_hypersurface/Project.toml
@@ -13,4 +13,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-Bcube = "0.2"
+Bcube = "0.2, 0.3"

--- a/src/example/transport_supg/Project.toml
+++ b/src/example/transport_supg/Project.toml
@@ -5,4 +5,4 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-Bcube = "0.1.2, 0.2"
+Bcube = "0.1.2, 0.2, 0.3"


### PR DESCRIPTION
To be merged only once Bcube 0.3 is released. I have checked the CI + some (but not all) examples such as the Naca, constrained Poisson and shallow water.